### PR TITLE
Docs: Fix Usage with React warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,10 +342,11 @@ import React, { useEffect, useRef } from "react";
 function useListener(ref, eventName, handler) {
   useEffect(() => {
     if (ref.current) {
-      ref.current.addEventListener(eventName, handler)
-      return () => ref.current.removeEventListener(eventName, handler)
+      const element = ref.current;
+      element.addEventListener(eventName, handler)
+      return () => element.removeEventListener(eventName, handler)
     }
-  }, [eventName, handler])
+  }, [eventName, handler, ref])
 }
 
 export function DatePicker({
@@ -363,7 +364,7 @@ export function DatePicker({
   useListener(ref, "duetBlur", onBlur)
 
   useEffect(() => {
-    ref.current.localization = localization,
+    ref.current.localization = localization
     ref.current.dateAdapter = dateAdapter
   }, [localization, dateAdapter])
 


### PR DESCRIPTION
Hey 👋 

First off, thanks very much for separating this out from the `duetds` design system. I was running into so many usability issues with date-pickers in the React ecosystem and then found this one. It's really great!

I was going through the docs, and copied the React example into an existing project. I was seeing a couple of warnings that I thought might be helpful to fix.

![Screenshot 2020-09-19 at 11 46 05](https://user-images.githubusercontent.com/12698531/93665470-9d434700-fa6e-11ea-9ee3-4b454c88c171.png)

![Screenshot 2020-09-19 at 11 45 50](https://user-images.githubusercontent.com/12698531/93665472-9ddbdd80-fa6e-11ea-93e2-a0da05395760.png)
