### PR TITLE
Bugfix/inside shadow dom

### DIFF
--- a/src/components/duet-date-picker/duet-date-picker.tsx
+++ b/src/components/duet-date-picker/duet-date-picker.tsx
@@ -233,7 +233,7 @@ export class DuetDatePicker implements ComponentInterface {
       return
     }
 
-    const target = e.target as Node
+    const target = e.composedPath()[0] as Node
 
     // TODO: stopPropagation only on open??
 

--- a/src/components/duet-date-picker/duet-date-picker.tsx
+++ b/src/components/duet-date-picker/duet-date-picker.tsx
@@ -233,8 +233,6 @@ export class DuetDatePicker implements ComponentInterface {
       return
     }
 
-    const target = e.composedPath ? (e.composedPath()[0] as Node) : (e.target as Node)
-
     // TODO: stopPropagation only on open??
 
     // the dialog and the button aren't considered clicks outside.
@@ -250,11 +248,14 @@ export class DuetDatePicker implements ComponentInterface {
     //    and open the new one. this means we can't stopPropagation() on the button itself
     //
     // this was the only satisfactory combination of things to get the above to work
-    if (this.dialogWrapperNode.contains(target) || this.datePickerButton.contains(target)) {
-      return
-    }
 
-    this.hide(false)
+    const isClickOutside = e
+      .composedPath()
+      .every(node => node !== this.dialogWrapperNode && node !== this.datePickerButton)
+
+    if (isClickOutside) {
+      this.hide(false)
+    }
   }
 
   /**

--- a/src/components/duet-date-picker/duet-date-picker.tsx
+++ b/src/components/duet-date-picker/duet-date-picker.tsx
@@ -233,7 +233,7 @@ export class DuetDatePicker implements ComponentInterface {
       return
     }
 
-    const target = e.composedPath()[0] as Node
+    const target = e.composedPath ? (e.composedPath()[0] as Node) : (e.target as Node)
 
     // TODO: stopPropagation only on open??
 


### PR DESCRIPTION

Fixes #64 

If an event is fired from within a component with shadow DOM and listened to outside (like document or window), the `event.target` will not pierce the shadow DOM and show as the top level component. For example, listening to a click event on the document in the following situation (if `foo-bar` had a shadow dom)
```
<foo-bar>
  <duet-date-picker></duet-date-picker>
</foo-bar>
```
will have `foo-bar` as the event target! Therefore the condition `if (this.dialogWrapperNode.contains(target) || this.datePickerButton.contains(target)) {` will not be met because target always returns a parent node!

Enter `composedPath` to the rescue. https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath 
It returns an array of nodes and will contain shadow dom nodes as long as it is `open`. 
I realized that `composedPath` is not supported in IE (IE doesn't support shadow dom at all), so if `composedPath` is available it will be used, otherwise it will fallback to target.