### PR TITLE
A minor change to remove disabled months from the drop down

### DIFF
--- a/src/components/duet-date-picker/duet-date-picker.tsx
+++ b/src/components/duet-date-picker/duet-date-picker.tsx
@@ -547,6 +547,9 @@ export class DuetDatePicker implements ComponentInterface {
     const minYear = minDate ? minDate.getFullYear() : selectedYear - 10
     const maxYear = maxDate ? maxDate.getFullYear() : selectedYear + 10
 
+    const minMonth = minDate ? minDate.getMonth() : 0
+    const maxMonth = maxDate ? maxDate.getMonth() : 11
+
     return (
       <Host>
         <div class="duet-date">
@@ -638,11 +641,15 @@ export class DuetDatePicker implements ComponentInterface {
                       ref={element => (this.monthSelectNode = element)}
                       onChange={this.handleMonthSelect}
                     >
-                      {this.localization.monthNames.map((month, i) => (
-                        <option key={month} value={i} selected={i === focusedMonth}>
-                          {month}
-                        </option>
-                      ))}
+                      {this.localization.monthNames.map(
+                        (month, i) =>
+                          i >= minMonth &&
+                          i <= maxMonth && (
+                            <option key={month} value={i} selected={i === focusedMonth}>
+                              {month}
+                            </option>
+                          )
+                      )}
                     </select>
                     <div class="duet-date__select-label" aria-hidden="true">
                       <span>{this.localization.monthNamesShort[focusedMonth]}</span>

--- a/src/components/duet-date-picker/duet-date-picker.tsx
+++ b/src/components/duet-date-picker/duet-date-picker.tsx
@@ -547,8 +547,8 @@ export class DuetDatePicker implements ComponentInterface {
     const minYear = minDate ? minDate.getFullYear() : selectedYear - 10
     const maxYear = maxDate ? maxDate.getFullYear() : selectedYear + 10
 
-    const minMonth = minDate ? minDate.getMonth() : 0
-    const maxMonth = maxDate ? maxDate.getMonth() : 11
+    const minMonth = minDate && minYear === maxYear ? minDate.getMonth() : 0
+    const maxMonth = maxDate && minYear === maxYear ? maxDate.getMonth() : 11
 
     return (
       <Host>


### PR DESCRIPTION
Hello,

I would like to thank you for the component one time more. It's pleasure to customize it. Unfortunately, I have to create something that looks like a calendar for selecting a date in the range of several months. But this small improvement could be interesting for you as well. I noticed that when you set min or max parameter (or both), the month drop down still contains all 12 months. Even thought it's not possible to select one due to min/max property. It can confuse some users (actually this is the only one reason why I had to dig into it). This small fix exclude the items that can't be selected.