### PR TITLE
Use aria-current to indicate the current date

### DIFF
--- a/src/components/duet-date-picker/date-picker-day.tsx
+++ b/src/components/duet-date-picker/date-picker-day.tsx
@@ -51,6 +51,7 @@ export const DatePickerDay: FunctionalComponent<DatePickerDayProps> = ({
       disabled={isOutsideRange}
       type="button"
       aria-pressed={isSelected ? "true" : "false"}
+      aria-current={isToday ? "date" : undefined}
       ref={el => {
         if (isFocused && el && focusedDayRef) {
           focusedDayRef(el)


### PR DESCRIPTION
We very much appreciate all the work you've done to develop and maintain this date picker solution!

A couple of suggestions were recommended to us by our external accessibility agency [Intopia](https://intopia.digital/), including indicating the current date with `aria-current`...

> The current day is only visually marked (with the class “is-today”), but not available to screen readers. Putting aria-current=”date” on the button would fix this.

Kind regards
Jonny @ Westpac GEL

Also raised...
- https://github.com/duetds/date-picker/issues/93, and
- https://github.com/duetds/date-picker/issues/94