### PR TITLE
docs: fix simple typo, coustom -> custom

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,7 +564,7 @@ Duet Date Picker offers full support for localization. This includes the text la
 </script>
 ```
 
-Please note that you must provide the entirety of the localization properties in the object when overriding with your coustom localization.
+Please note that you must provide the entirety of the localization properties in the object when overriding with your custom localization.
 
 ## Control which days are selectable
 


### PR DESCRIPTION
There is a small typo in README.md.

Should read `custom` rather than `coustom`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md