### PR TITLE
Add moveFocusToCalendar parameter to show()

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,9 +155,10 @@ Sets focus on the date picker's input. Use this method instead of the global `fo
 
 Type: `Promise<void>`
 
-### `show() => Promise<void>`
+### `show(moveFocusToCalendar?: boolean) => Promise<void>`
 
-Show the calendar modal, moving focus to the calendar inside.
+Show the calendar modal. Set `moveFocusToCalendar` to false to prevent
+the focus from moving to the calendar. Default is true.
 
 #### Returns
 

--- a/src/components/duet-date-picker/duet-date-picker.tsx
+++ b/src/components/duet-date-picker/duet-date-picker.tsx
@@ -311,17 +311,20 @@ export class DuetDatePicker implements ComponentInterface {
   }
 
   /**
-   * Show the calendar modal, moving focus to the calendar inside.
+   * Show the calendar modal. Set `moveFocusToCalendar` to false to prevent
+   * the focus from moving to the calendar. Default is true.
    */
-  @Method() async show() {
+  @Method() async show(moveFocusToCalendar = true) {
     this.open = true
     this.duetOpen.emit({
       component: "duet-date-picker",
     })
-    this.setFocusedDay(parseISODate(this.value) || new Date())
 
-    clearTimeout(this.focusTimeoutId)
-    this.focusTimeoutId = setTimeout(() => this.monthSelectNode.focus(), TRANSITION_MS)
+    this.setFocusedDay(parseISODate(this.value) || new Date())
+    if (moveFocusToCalendar) {
+      clearTimeout(this.focusTimeoutId)
+      this.focusTimeoutId = setTimeout(() => this.monthSelectNode.focus(), TRANSITION_MS)
+    }
   }
 
   /**

--- a/src/components/duet-date-picker/readme.md
+++ b/src/components/duet-date-picker/readme.md
@@ -58,9 +58,10 @@ Type: `Promise<void>`
 
 
 
-### `show() => Promise<void>`
+### `show(moveFocusToCalendar?: boolean) => Promise<void>`
 
-Show the calendar modal, moving focus to the calendar inside.
+Show the calendar modal. Set `moveFocusToCalendar` to false to prevent
+the focus from moving to the calendar. Default is true.
 
 #### Returns
 


### PR DESCRIPTION
This PR adds an option to `show()` for opening the calendar without changing the focus. This option could be useful in cases where focusing the calendar would be confusing (for example, opening the calendar when the input is focused, as described in #90).

Duet date picker is awesome - thank you for building and open-sourcing it! 😄 